### PR TITLE
altera context do botão delete

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,26 +8,46 @@ import { EditarArquivoPage } from './pages/EditarArquivoPage';
 import { NotFoundPage } from './pages/NotFoundPage';
 import { Layout } from './components/Layout';
 import { RequireAuth } from './components/RequireAuth';
+import { DeletedContext } from './data/DeletedContext';
+import { useState } from 'react';
 
 function App() {
+  const [ deleted, setDeleted ] = useState<boolean>(false);
+
   return (
     <>
-      <Routes>
+    <Routes>
       <Route path="/login" element={<LoginPage />} />
+    
+        <Route path="/" element={<Layout />}>
+          <Route 
+            index 
+            element={
+              <DeletedContext.Provider 
+                value={{ deleted, setDeleted }} >
+                <ArtigosPage />
+              </DeletedContext.Provider>
+            }
+          />
+          <Route path="/artigo/:id" element={<ArtigoPage />} />
 
-      <Route path="/" element={<Layout />}>
-        <Route index element={<ArtigosPage />} />
-        <Route path="/artigo/:id" element={<ArtigoPage />} />
-
-        <Route element={ <RequireAuth /> }>
-          <Route path="/artigos" element={<MeusArtigosPage />} />
-          <Route path="/artigos/editar/:id" element={<EditarArquivoPage />} />
-          <Route path="/artigos/novo" element={<EditarArquivoPage />} />
+          <Route element={ <RequireAuth /> }>
+            <Route 
+              path="/artigos"
+              element={
+                <DeletedContext.Provider 
+                  value={{ deleted, setDeleted }} >
+                  <MeusArtigosPage />
+                </DeletedContext.Provider>
+              }
+            />
+            <Route path="/artigos/editar/:id" element={<EditarArquivoPage />} />
+            <Route path="/artigos/novo" element={<EditarArquivoPage />} />
+          </Route>
         </Route>
-      </Route>
 
       <Route path="*" element={<NotFoundPage />} />
-      </Routes>
+    </Routes>
     </>
   );
 }

--- a/src/components/ArticleThumbnail/index.tsx
+++ b/src/components/ArticleThumbnail/index.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from "react";
-import { useContext } from "react";
 import { Link } from "react-router-dom";
-import { DataContext } from "../../data/DataContext";
+import { useDeleted } from "../../data/DeletedContext";
 import { formataData } from "../../helpers/date";
+import apiClient from "../../services/api-client";
 import { ArticleThumbnailProps } from "./ArticleThumbnail.types";
 
 export const ArticleThumbnail: React.FC<ArticleThumbnailProps> = ({
@@ -17,8 +17,21 @@ export const ArticleThumbnail: React.FC<ArticleThumbnailProps> = ({
   const verArtigo = `/artigo/${id}`
   const editarArtigo = `/artigos/editar/${id}`
   const [ editavel, setEditavel ] = useState(false)
+  const [ erro, setErro ] = useState('')
 
-  const remove = useContext(DataContext)
+  const {deleted, setDeleted} = useDeleted()
+  
+  async function remove(id:number) {
+    try {
+      await apiClient.delete(`/artigos/${id}`) 
+      deleted ? setDeleted(false) : setDeleted(true)
+      console.log("artigo deletado")
+    } catch (error:any ) {
+      error.response.data.statusCode === 401 ?
+        setErro('Unauthorized') :
+        setErro('Erro ao deletar artigo')
+    }
+  }
 
   useEffect (()=> {
     const idLocalStorage = Number(localStorage.getItem("id"))

--- a/src/data/DataContext.ts
+++ b/src/data/DataContext.ts
@@ -1,4 +1,0 @@
-import React from "react"
-
-export const DataContext =
- React.createContext( async (id:number):Promise<void> => {} )

--- a/src/data/DeletedContext.ts
+++ b/src/data/DeletedContext.ts
@@ -1,0 +1,27 @@
+import React, { 
+  useContext,
+  Dispatch, 
+  SetStateAction,
+} from "react"
+
+type Deleted = {
+  deleted: boolean , 
+  setDeleted: Dispatch<SetStateAction< boolean >>;
+}
+
+export const DeletedContext = React.createContext<Deleted>({
+  deleted: false , 
+  setDeleted: () => {}
+});
+
+
+export const useDeleted = () => {
+  const ctx = useContext(DeletedContext)
+
+  if (ctx === undefined)
+   throw new Error
+   ("useDeleted must be used within a DeletedProvider")
+
+  return ctx
+}
+

--- a/src/pages/ArtigosPage/index.tsx
+++ b/src/pages/ArtigosPage/index.tsx
@@ -3,15 +3,18 @@ import { useEffect, useState } from "react";
 import { ArticleList } from "../../components/ArticleList";
 import { ArticleThumbnailProps } from "../../components/ArticleThumbnail/ArticleThumbnail.types";
 import { Carregando } from "../../components/Carregando";
+import { useDeleted } from "../../data/DeletedContext";
 
 export const ArtigosPage = () => {
     const [articles, setArticles] = useState<ArticleThumbnailProps[]>([]);
     const [ showComponent, setShowComponent ] = useState(false)
     const [ erro, setErro ] = useState('')
-    useEffect(() => { buscaArtigos() }, []);
 
+    const {deleted}= useDeleted()
+    
     async function buscaArtigos() {
         setErro('')
+        setShowComponent(false)
 
         try { 
             const response = await apiClient.get<ArticleThumbnailProps[]>("/artigos")
@@ -23,6 +26,9 @@ export const ArtigosPage = () => {
         }
         setShowComponent(true)
     }
+
+    useEffect(() => { buscaArtigos() }, []);
+    useEffect(() => { buscaArtigos() }, [deleted]);
 
     return ( showComponent ? 
         <ArticleList articles={articles}/> :

--- a/src/pages/MeusArtigosPage/index.tsx
+++ b/src/pages/MeusArtigosPage/index.tsx
@@ -3,17 +3,17 @@ import { useEffect, useState } from "react";
 
 import { ArticleList } from "../../components/ArticleList";
 import { ArticleThumbnailProps } from "../../components/ArticleThumbnail/ArticleThumbnail.types";
-import { DataContext } from "../../data/DataContext";
+import { useDeleted } from "../../data/DeletedContext";
 
 export const MeusArtigosPage = () => {
   const [articles, setArticles] = useState<ArticleThumbnailProps[]>([]);
   const [ showComponent, setShowComponent ] = useState(false)
   const [ erro, setErro ] = useState("")
-  const [ artigoDeletado, setArtigoDeletado ] = useState(false)
 
+  const {deleted} = useDeleted()
+  
   async function buscaMeusArtigos() {
     setErro('')
-    
     try { 
       const response = await apiClient.get<ArticleThumbnailProps[]>
       ('/artigos/meus-artigos');
@@ -27,28 +27,11 @@ export const MeusArtigosPage = () => {
     setShowComponent(true) 
   }
 
-  useEffect(() => {
-    buscaMeusArtigos();
-  }, []);
-
-  useEffect(() => {
-    buscaMeusArtigos();
-  }, [artigoDeletado]);
-
-  async function remove(id:number) {
-    try {
-      setArtigoDeletado( await apiClient.delete(`/artigos/${id}`) )
-    } catch (error:any ) {
-      error.response.data.statusCode === 401 ?
-        setErro('Unauthorized') :
-        setErro('Erro ao deletar artigo')
-    }
-  }
+  useEffect(() => { buscaMeusArtigos() }, []);
+  useEffect(() => { buscaMeusArtigos()}, [deleted]);
 
   return ( showComponent ?
-    <DataContext.Provider value={remove} >
-      <ArticleList articles={articles}/>
-    </DataContext.Provider> :
+    <ArticleList articles={articles}/> :
     <div />
   );
 };


### PR DESCRIPTION
Corrige bug da página inicial. Ao clicar no botão delete do article thumbnail na home page, a thumbnail do artigo excluído continuava aparecendo. Bug corrigido. Além disso, refatora dado passado por contexto. Em vez de passar a função remove, o contexto agora passa um estado para a aplicação saber se deve atualizar as páginas meus artigos e home. 